### PR TITLE
Explicit configmap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module "fluxcd" {
 | <a name="input_irsa_role_arn"></a> [irsa\_role\_arn](#input\_irsa\_role\_arn) | Arn of IRSA role that is mapped to kustomize-controller service account in flux-system namespace | `string` | n/a | yes |
 | <a name="input_path"></a> [path](#input\_path) | Path relative to flux repository root where to look for manifests | `string` | n/a | yes |
 | <a name="input_annotations"></a> [annotations](#input\_annotations) | Annotations to add to created kubernetes resources | `map(string)` | `{}` | no |
-| <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
+| <a name="input_cluster_variables"></a> [cluster\_variables](#input\_cluster\_variables) | Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use | `map(string)` | `{}` | no |
 | <a name="input_controller_ssh_known_hosts"></a> [controller\_ssh\_known\_hosts](#input\_controller\_ssh\_known\_hosts) | SSH known hosts for flux controller. Defaults to github.com ECDSA key. | `string` | `"github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="` | no |
 | <a name="input_fluxcd_version"></a> [fluxcd\_version](#input\_fluxcd\_version) | Flux version to use | `string` | `"v2.1.1"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy fluxcd to | `string` | `"flux-system"` | no |

--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,7 @@ resource "kubernetes_config_map" "flux_cluster_variables" {
   count = length(var.cluster_variables) > 0 ? 1 : 0
 
   metadata {
-    name        = "flux-cluster-variables"
+    name        = "terraform-flux-cluster-variables"
     namespace   = var.namespace
     annotations = var.annotations
   }

--- a/variables.tf
+++ b/variables.tf
@@ -40,7 +40,7 @@ variable "annotations" {
 }
 
 variable "cluster_variables" {
-  description = "Key-value pairs to create 'flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use"
+  description = "Key-value pairs to create 'terraform-flux-cluster-variables' ConfigMap for flux/Kustomization postBuild use"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
It perhaps would be more explicit to indicate in the configmap name, it became from terraform, so add explicit prefix.